### PR TITLE
Publish docker image to GitHub Container Registry

### DIFF
--- a/.github/workflows/router-workflow.yml
+++ b/.github/workflows/router-workflow.yml
@@ -53,4 +53,15 @@ jobs:
       - name: Run services
         run: docker-compose up -d
 
+  docker-publish:
+    if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Build and publish docker image for ${{ github.repository }}
+        uses: macbre/push-to-ghcr@master
+        with:
+          image_name: ${{ github.repository }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+
 


### PR DESCRIPTION
* Add a job in router workflow to build the docker image and publish to GitHub Container Registry.